### PR TITLE
OBE-9822: Validate download URL and verify binary integrity before ex…

### DIFF
--- a/edge/install.ps1
+++ b/edge/install.ps1
@@ -110,6 +110,19 @@ function Parse-EnvironmentVariable {
     if ($EnvVar -match "download_url=([^\s]+)") {
         $script:DefaultDownloadUrl = $matches[1]
         Write-Host "Updated DefaultDownloadUrl to: $DefaultDownloadUrl"
+
+        # Reject non-HTTPS schemes
+        $uri = [Uri]$script:DefaultDownloadUrl
+        if ($uri.Scheme -ne 'https') {
+            Write-Host "Error: download_url must use HTTPS (got: $($uri.Scheme))"
+            return $false
+        }
+
+        # Validate hostname against allowlist — only S3 and the Observo CDN are permitted
+        if ($uri.Host -notmatch '^([a-z0-9-]+\.s3(\.[a-z0-9-]+)?\.amazonaws\.com|downloads\.observo\.ai)$') {
+            Write-Host "Error: download_url hostname '$($uri.Host)' is not in the allowed list"
+            return $false
+        }
     } else {
         Write-Host "No DownloadUrl provided: $DefaultDownloadUrl"
         return $false
@@ -174,6 +187,12 @@ function Decode-AndExtractConfig {
         $script:FleetId = $config.fleet_id
         $script:Platform = $config.platform
         $script:EdgeManagerUrl = $config.edge_manager_url
+        $script:BinarySha256 = $config.sha256
+
+        if (-not $script:BinarySha256) {
+            Write-Host "Error: install_id payload is missing required 'sha256' field. Cannot verify binary integrity." -ForegroundColor Red
+            exit 1
+        }
 
         Write-Host "SITE_ID: $SiteId"
         Write-Host "AUTH_TOKEN: $AuthToken"
@@ -206,6 +225,18 @@ function Download-AndExtractAgent {
         $webClient = New-Object System.Net.WebClient
         $webClient.DownloadFile($DownloadUrl, $ZipFile)
         Write-Host "Download completed and saved to $ZipFile"
+
+        # Verify SHA-256 integrity before extraction
+        Write-Host "Verifying SHA-256 integrity..."
+        $actualHash = (Get-FileHash -Path $ZipFile -Algorithm SHA256).Hash.ToLower()
+        if ($actualHash -ne $script:BinarySha256.ToLower()) {
+            Write-Host "Error: SHA-256 mismatch — binary integrity check failed." -ForegroundColor Red
+            Write-Host "  Expected: $($script:BinarySha256)"
+            Write-Host "  Got:      $actualHash"
+            Remove-Item -Path $ZipFile -Force -ErrorAction SilentlyContinue
+            exit 1
+        }
+        Write-Host "SHA-256 verified: $actualHash"
 
         # Create extract directory if it doesn't exist
         if (-not (Test-Path -Path $ExtractDir)) {

--- a/edge/install.sh
+++ b/edge/install.sh
@@ -111,6 +111,19 @@ parse_environment_variable() {
         DOWNLOAD_URL="${BASH_REMATCH[1]}"  # Extract the full presigned URL
         echo "Extracted download_url: $DOWNLOAD_URL"
 
+        # Reject non-HTTPS schemes
+        if [[ ! "$DOWNLOAD_URL" =~ ^https:// ]]; then
+            echo "Error: download_url must use HTTPS (got: ${DOWNLOAD_URL%%://*}://)"
+            return 1
+        fi
+
+        # Validate hostname against allowlist — only S3 and the Observo CDN are permitted
+        DOWNLOAD_HOST=$(echo "$DOWNLOAD_URL" | sed 's|^https://||' | cut -d'/' -f1 | cut -d'?' -f1)
+        if [[ ! "$DOWNLOAD_HOST" =~ ^([a-z0-9-]+\.s3(\.[a-z0-9-]+)?\.amazonaws\.com|downloads\.observo\.ai)$ ]]; then
+            echo "Error: download_url hostname '${DOWNLOAD_HOST}' is not in the allowed list"
+            return 1
+        fi
+
         export DOWNLOAD_URL  # Make it available to other functions
     else
         echo "Error: download_url not found in argument"
@@ -168,6 +181,13 @@ decode_and_extract_config() {
     FLEET_ID=$(echo "$PAYLOAD" | jq -r '.fleet_id')
     PLATFORM=$(echo "$PAYLOAD" | jq -r '.platform')
     EDGE_MANAGER_URL=$(echo "$PAYLOAD" | jq -r '.edge_manager_url')
+    BINARY_SHA256=$(echo "$PAYLOAD" | jq -r '.sha256 // empty')
+
+    if [[ -z "$BINARY_SHA256" ]]; then
+        echo "Error: install_id payload is missing required 'sha256' field. Cannot verify binary integrity."
+        exit 1
+    fi
+    export BINARY_SHA256
 
     echo "SITE_ID: $SITE_ID"
     echo "AUTH_TOKEN: $AUTH_TOKEN"
@@ -238,9 +258,25 @@ download_and_extract_agent() {
     
     echo "Download completed and saved to $TAR_FILE (size: $FILE_SIZE bytes)"
 
+    echo "Verifying SHA-256 integrity..."
+    ACTUAL_SHA256=$(sha256sum "$TAR_FILE" 2>/dev/null | cut -d' ' -f1 || shasum -a 256 "$TAR_FILE" 2>/dev/null | awk '{print $1}')
+    if [[ -z "$ACTUAL_SHA256" ]]; then
+        echo "Error: Could not compute SHA-256 hash (neither sha256sum nor shasum available)"
+        rm -f "$TAR_FILE"
+        exit 1
+    fi
+    if [[ "$ACTUAL_SHA256" != "$BINARY_SHA256" ]]; then
+        echo "Error: SHA-256 mismatch — binary integrity check failed."
+        echo "  Expected: $BINARY_SHA256"
+        echo "  Got:      $ACTUAL_SHA256"
+        rm -f "$TAR_FILE"
+        exit 1
+    fi
+    echo "SHA-256 verified: $ACTUAL_SHA256"
+
     mkdir -p "$EXTRACT_DIR"
     echo "Extracting $TAR_FILE to $EXTRACT_DIR"
-    tar -xzvf "$TAR_FILE" -C "$EXTRACT_DIR" || { echo "Extraction failed!"; exit 1; }
+    tar -xzvf "$TAR_FILE" --no-same-owner -C "$EXTRACT_DIR" || { echo "Extraction failed!"; exit 1; }
     echo "Extraction complete. Files are in $EXTRACT_DIR"
 }
 


### PR DESCRIPTION
Validate download URL and verify binary integrity before extraction

Fixes critical supply-chain RCE (OB01/OB16): install.sh and install.ps1 now reject non-HTTPS schemes and non-allowlisted hostnames, require a sha256 field in the install_id JWT, and verify the downloaded tarball/zip against that hash before tar/Expand-Archive runs.